### PR TITLE
Dash apps

### DIFF
--- a/pollination_apps/cli/__init__.py
+++ b/pollination_apps/cli/__init__.py
@@ -66,7 +66,12 @@ def login(environment: str, token_name: str):
 @click.option('-n', '--name', help='the name of the app.')
 @click.option('-t', '--tag', help='the tag for this version of the app')
 @click.option(
-    '-m', '--message', help='the commit message for this version of the app', 
+    '--sdk',
+    type=click.Choice(['streamlit', 'dash']),
+    default='streamlit', show_default=True,
+)
+@click.option(
+    '-m', '--message', help='the commit message for this version of the app',
     show_default=True,
     default='A new version of the app.'
 )
@@ -88,7 +93,7 @@ def login(environment: str, token_name: str):
     '-at', '--api-token', type=str, help='A valid Pollination API token', default=None,
     show_default=True
 )
-def deploy(path, owner, name, tag, message, environment, public, entrypoint,  api_token):
+def deploy(path, owner, name, tag, sdk, message, environment, public, entrypoint,  api_token):
     """Deploy a new version of the application.
 
     \b
@@ -130,7 +135,7 @@ def deploy(path, owner, name, tag, message, environment, public, entrypoint,  ap
     try:
         client.update_app(owner=owner, slug=slug, public=public)
     except:
-        client.create_app(owner, name, public)
+        client.create_app(owner, name, public, sdk)
 
     upload_link = client.get_upload_link(
         owner=owner,
@@ -174,7 +179,7 @@ def new(path):
 @click.option('-n', '--name', help='The name of the app.')
 @click.option('-t', '--tag', help='The tag for this version of the app')
 @click.option('-e', '--editable', help='An option to set the container to be editable '
-              'by mounting the app path as a volume to the docker container. ', 
+              'by mounting the app path as a volume to the docker container. ',
               default=False, show_default=True, is_flag=True)
 @click.option('--docker/--podman', help='An option to set the preferred container '
               'technology. The default is set to docker. You can also use podman as '

--- a/pollination_apps/client.py
+++ b/pollination_apps/client.py
@@ -59,12 +59,13 @@ class APIClient(object):
             slug=slug,
         )
 
-    def create_app(self, owner: str, name: str, public: bool = True):
+    def create_app(self, owner: str, name: str, public: bool = True, app_sdk: str = 'streamlit'):
         self.applications.create_application(
             owner=owner,
             application_create=sdk.ApplicationCreate(
                 name=name,
                 public=public,
+                sdk=app_sdk,
             )
         )
 

--- a/pollination_apps/template/assets/cookiecutter.json
+++ b/pollination_apps/template/assets/cookiecutter.json
@@ -1,9 +1,23 @@
 {
   "app_name": "My first app",
   "app_slug": "{{ cookiecutter.app_name.lower().replace(' ', '-') }}",
+  "sdk": [
+    "streamlit",
+    "dash"
+  ],
   "project_short_description": "My first Pollination app!",
   "app_owner": "",
-  "pollination_viewer": ["no", "yes"],
-  "app_visibility": ["public", "private"],
-  "ci": ["none", "github-manual", "github-automated"]
+  "pollination_viewer": [
+    "no",
+    "yes"
+  ],
+  "app_visibility": [
+    "public",
+    "private"
+  ],
+  "ci": [
+    "none",
+    "github-manual",
+    "github-automated"
+  ]
 }

--- a/pollination_apps/template/assets/{{cookiecutter.app_slug}}/.github/workflows/ci-automated.yaml
+++ b/pollination_apps/template/assets/{{cookiecutter.app_slug}}/.github/workflows/ci-automated.yaml
@@ -100,9 +100,9 @@ jobs:
           TAG=$(echo "${TAG:?}" | sed 's/[[:space:]]//g')
           TAG=${TAG%%-*}
 
-          echo pollination-apps deploy app --tag $TAG --owner {{cookiecutter.app_owner}} --name {% raw %}"${{needs.generate-app-name.outputs.app-name}}"{% endraw %} --{{cookiecutter.app_visibility}} --message {% raw %}"${{github.event.commits[0].message}}"{% endraw %} 
+          echo pollination-apps deploy app --tag $TAG --owner {{cookiecutter.app_owner}} --name {% raw %}"${{needs.generate-app-name.outputs.app-name}}"{% endraw %} --sdk {{ cookiecutter.sdk }} --{{cookiecutter.app_visibility}} --message {% raw %}"${{github.event.commits[0].message}}"{% endraw %} 
 
-          pollination-apps deploy app --tag $TAG --owner {{cookiecutter.app_owner}} --name {% raw %}"${{needs.generate-app-name.outputs.app-name}}"{% endraw %} --{{cookiecutter.app_visibility}} --message {% raw %}"${{github.event.commits[0].message}}"{% endraw %} 
+          pollination-apps deploy app --tag $TAG --owner {{cookiecutter.app_owner}} --name {% raw %}"${{needs.generate-app-name.outputs.app-name}}"{% endraw %} --sdk {{ cookiecutter.sdk }} --{{cookiecutter.app_visibility}} --message {% raw %}"${{github.event.commits[0].message}}"{% endraw %} 
 
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/pollination_apps/template/assets/{{cookiecutter.app_slug}}/.github/workflows/ci-manual.yaml
+++ b/pollination_apps/template/assets/{{cookiecutter.app_slug}}/.github/workflows/ci-manual.yaml
@@ -25,6 +25,6 @@ jobs:
           pip install pollination-apps
       - name: deploy app to pollination
         run: |
-          pollination-apps deploy app --owner {{cookiecutter.app_owner}} --name "{{cookiecutter.app_name}}" --tag {%raw%}${{ env.RELEASE_VERSION }}{%endraw%} --{{cookiecutter.app_visibility}}
+          pollination-apps deploy app --owner {{cookiecutter.app_owner}} --name "{{cookiecutter.app_name}}" --sdk {{ cookiecutter.sdk }} --tag {%raw%}${{ env.RELEASE_VERSION }}{%endraw%} --{{cookiecutter.app_visibility}}
         env:
           POLLINATION_TOKEN: {% raw %}${{ secrets.POLLINATION_TOKEN }}{% endraw %}

--- a/pollination_apps/template/assets/{{cookiecutter.app_slug}}/README.md
+++ b/pollination_apps/template/assets/{{cookiecutter.app_slug}}/README.md
@@ -10,6 +10,7 @@ Install dependencies:
 > pip install -r requirements.txt
 ```
 
+{% if cookiecutter.sdk == "streamlit" %}
 Start Streamlit
 
 ```
@@ -21,6 +22,23 @@ Start Streamlit
   External URL: http://152.37.119.122:8501
 
 ```
+{% elif cookiecutter.sdk == "dash" %}
+Start Dash
+
+```
+> python app.py
+
+    Dash is running on http://127.0.0.1:8050/
+
+    * Serving Flask app 'app' (lazy loading)
+    * Environment: production
+      WARNING: This is a development server. Do not use it in a production deployment.
+      Use a production WSGI server instead.
+    * Debug mode: on
+    * Running on http://127.0.0.1:8050 (Press CTRL+C to quit)
+
+```
+{% endif %}
 
 Make changes to your app in the `app.py` file inside the "app" folder.
 
@@ -37,7 +55,7 @@ You need to install Docker on your machine in order to be able to run this comma
 ## Deploy to Pollination
 
 ```
-> pollination-apps deploy app --name "{{ cookiecutter.app_name }}" --{{ cookiecutter.app_visibility }} --api-token "Your api token from Pollination"
+> pollination-apps deploy app --name "{{ cookiecutter.app_name }}" --sdk {{ cookiecutter.sdk }} --{{ cookiecutter.app_visibility }} --api-token "Your api token from Pollination"
 ```
 
 {% if cookiecutter.ci == "github-manual" %}

--- a/pollination_apps/template/assets/{{cookiecutter.app_slug}}/app/app.py
+++ b/pollination_apps/template/assets/{{cookiecutter.app_slug}}/app/app.py
@@ -1,3 +1,20 @@
+{%- if cookiecutter.sdk == "streamlit" -%}
 import streamlit as st
 
 st.write("Welcome! Start writing your Pollination app here.")
+
+{%- elif cookiecutter.sdk == "dash" -%}
+from dash import Dash, html
+
+app = Dash(__name__)
+app.title = "Hello Pollination"
+
+server = app.server
+
+app.layout = html.Div([
+    html.Div(children='Welcome! Start writing your Pollination app here.')
+])
+
+if __name__ == '__main__':
+    app.run_server(debug=True)
+{% endif %}

--- a/pollination_apps/template/assets/{{cookiecutter.app_slug}}/app/requirements.txt
+++ b/pollination_apps/template/assets/{{cookiecutter.app_slug}}/app/requirements.txt
@@ -1,1 +1,6 @@
+{%- if cookiecutter.sdk == "streamlit" -%}
 pollination-streamlit>=0.5.0
+{%- elif cookiecutter.sdk == "dash" -%}
+dash
+gunicorn
+{% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pollination-sdk>=0.27.0
+pollination-sdk>=0.43.0
 pydantic==1.8.2
 PyYAML==5.4.1
 jsonschema==3.2.0


### PR DESCRIPTION
This Pull Request adds support for dash apps.

You can test the whole flow out (in staging) by creating a new app using `pollination-apps new` and selecting the `dash` SDK option.

You should then be able to follow the instructions and create an app that matches this one: https://app.staging.pollination.cloud/antoinedao/apps/dash-test?tab=live+app