### PR TITLE
fix(domains): use correct domain when uploading files

### DIFF
--- a/pollination_apps/cli/__init__.py
+++ b/pollination_apps/cli/__init__.py
@@ -1,19 +1,18 @@
 import os
 import pathlib
-import subprocess
 import signal
-from urllib.parse import urlparse
+import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 import click
 from click import ClickException
 from slugify.slugify import slugify
 
+from ..config import Config
 from ..env import Environment
 from ..template import generate_template, generate_template_non_interactive
 from .context import Context
-from ..config import Config
-
 
 MODULE_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -152,8 +151,8 @@ def deploy(path, owner, name, tag, sdk, message, environment, public, entrypoint
         path=path,
     )
 
-    base_url = 'https://app.staging.pollination.cloud' if environment == 'staging' \
-        else 'https://app.pollination.cloud'
+    base_url = 'https://app.staging.pollination.solutions' if environment == 'staging' \
+        else 'https://app.pollination.solutions'
 
     click.echo(
         f'\nCongrats! The "{name}" app is successfully scheduled for deployment.\n'
@@ -190,7 +189,7 @@ def new(path, sdk):
 def new_from_url(url, api_token):
     """Import an app from a git repository."""
     # Example input
-    # https://app.pollination.cloud/{owner}/apps/{slug}
+    # https://app.pollination.solutions/{owner}/apps/{slug}
     # get antoinedao and testy-test-test
     owner, _, slug = url.split('/')[-3:]
 

--- a/pollination_apps/client.py
+++ b/pollination_apps/client.py
@@ -9,7 +9,7 @@ import requests
 class APIClient(object):
     """A Pollination client designed to interact with Workflow and Simulation objects."""
 
-    def __init__(self, api_token=None, access_token=None, host='https://api.pollination.cloud'):
+    def __init__(self, api_token=None, access_token=None, host='https://api.pollination.solutions'):
         self.config = sdk.Configuration()
         if api_token is not None:
             self.set_api_token(api_token)

--- a/pollination_apps/env.py
+++ b/pollination_apps/env.py
@@ -18,12 +18,12 @@ class Environment:
     @property
     def api_host(self) -> str:
         if self._env == EnvironmentEnum.staging:
-            return 'https://api.staging.pollination.cloud'
+            return 'https://api.staging.pollination.solutions'
         else:
-            return 'https://api.pollination.cloud'
+            return 'https://api.pollination.solutions'
 
     @property
     def login_url(self) -> str:
         if self._env == EnvironmentEnum.staging:
-            return 'https://auth.staging.pollination.cloud/sdk-login'
-        return 'https://auth.pollination.cloud/sdk-login'
+            return 'https://auth.staging.pollination.solutions/sdk-login'
+        return 'https://auth.pollination.solutions/sdk-login'

--- a/pollination_apps/login.py
+++ b/pollination_apps/login.py
@@ -29,7 +29,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         return
 
 
-def interactive_login(url: str = 'https://auth.pollination.cloud/sdk-login') -> str:
+def interactive_login(url: str = 'https://auth.pollination.solutions/sdk-login') -> str:
     httpd = ThreadingHTTPServer((IP, PORT), RequestHandler)
     webbrowser.open_new(url)
     httpd.serve_forever()

--- a/pollination_apps/template/dash/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
+++ b/pollination_apps/template/dash/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
@@ -54,7 +54,7 @@ In order to configure github actions to deploy your app you will need to:
 2. [Add](https://docs.github.com/en/actions/security-guides/encrypted-secrets) a secret called `POLLINATION_TOKEN` with your Pollination API key as the value
 3. Create [a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) of your app on Github with a new tag
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}
 
@@ -88,6 +88,6 @@ In order to configure github actions to deploy your app you will need to:
 
    **Note** that the commit messages with only `fix` and `feat` type will trigger a deployment to Pollination.
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}

--- a/pollination_apps/template/dash/{{cookiecutter.app_name.lower().replace(' ', '-') }}/app/app.py
+++ b/pollination_apps/template/dash/{{cookiecutter.app_name.lower().replace(' ', '-') }}/app/app.py
@@ -1,11 +1,13 @@
 import os
-import pollination_dash_io
+
 import dash
+import dash_renderjson
+import pollination_dash_io
 from dash import html
 from dash.dependencies import Input, Output
-import dash_renderjson
 
-base_path = os.getenv('POLLINATION_API_URL', 'https://api.pollination.cloud')
+base_path = os.getenv('POLLINATION_API_URL',
+                      'https://api.pollination.solutions')
 
 app = dash.Dash(__name__)
 server = app.server
@@ -23,17 +25,20 @@ app.layout = html.Div([
     html.Div(id='output-form')
 ])
 
-api_key.create_api_key_callback(app=app, component_ids=['auth-user', 'po-select-project'])
+api_key.create_api_key_callback(
+    app=app, component_ids=['auth-user', 'po-select-project'])
+
 
 @app.callback(
     Output(component_id='output-form',
-      component_property='children'),
+           component_property='children'),
     Input(component_id='po-select-project',
-      component_property='project')
+          component_property='project')
 )
 def get_value_from_recipe_form(data):
     return dash_renderjson.DashRenderjson(id='json-out',
-                                          data={ 'project': data })
+                                          data={'project': data})
+
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/pollination_apps/template/react/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
+++ b/pollination_apps/template/react/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
@@ -32,7 +32,7 @@ In order to configure github actions to deploy your app you will need to:
 2. [Add](https://docs.github.com/en/actions/security-guides/encrypted-secrets) a secret called `POLLINATION_TOKEN` with your Pollination API key as the value
 3. Create [a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) of your app on Github with a new tag
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}
 
@@ -66,6 +66,6 @@ In order to configure github actions to deploy your app you will need to:
 
    **Note** that the commit messages with only `fix` and `feat` type will trigger a deployment to Pollination.
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}

--- a/pollination_apps/template/streamlit/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
+++ b/pollination_apps/template/streamlit/{{cookiecutter.app_name.lower().replace(' ', '-') }}/README.md
@@ -50,7 +50,7 @@ In order to configure github actions to deploy your app you will need to:
 2. [Add](https://docs.github.com/en/actions/security-guides/encrypted-secrets) a secret called `POLLINATION_TOKEN` with your Pollination API key as the value
 3. Create [a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) of your app on Github with a new tag
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}
 
@@ -84,6 +84,6 @@ In order to configure github actions to deploy your app you will need to:
 
    **Note** that the commit messages with only `fix` and `feat` type will trigger a deployment to Pollination.
 
-Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.cloud/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
+Github actions will then package and deploy your code to an app called [{{ cookiecutter.app_name }}](https://app.pollination.solutions/{{ cookiecutter.app_owner }}/applications/{{ cookiecutter.app_name.lower().replace(' ', '-') }})
 
 {% endif %}


### PR DESCRIPTION
This should fix the issue raised last week about receiving 405 responses for the server: https://3.basecamp.com/4298486/buckets/20761313/todos/7919458279

For a reason I am not entirely clear on, the redirect function was not redirecting the file upload requests properly. I think we have accepted that the redirect function from .cloud to .solutions is not going to work reliably for API calls and therefore where possible it is safer to simply change the hardcoded references from .cloud to .solutions.

This is what this PR does and I can confirm that it works as expected. This is also safe to release to production because the .solutions domains are ready to roll 😀